### PR TITLE
Change `build` to `applesimutils` to fix build error

### DIFF
--- a/buildForBrew.sh
+++ b/buildForBrew.sh
@@ -2,4 +2,4 @@ targetDir="$1"
 
 xcodebuild clean build -project applesimutils/applesimutils.xcodeproj -scheme applesimutils -configuration Release -derivedDataPath ./build
 mkdir -p "$targetDir"/bin
-cp build/Build/Products/Release/applesimutils "$targetDir"/bin
+cp applesimutils/Build/Products/Release/applesimutils "$targetDir"/bin


### PR DESCRIPTION
This fixes the following build error:

`brew install --HEAD applesimutils` failed with `cp: build/Build/Products/Release/applesimutils: No such file or directory error.`

Looking at where the build is saved, it is in `applesimutils/Build/Products/Release/applesimutils` not `build/Build/Products/Release/applesimutils`, changing the relevant line allowed it to complete.

full log:
```
→ brew install --HEAD applesimutils
==> Installing applesimutils from wix/brew
==> Cloning https://github.com/wix/AppleSimulatorUtils.git
Cloning into '/Users/chirag/Library/Caches/Homebrew/applesimutils--git'...
remote: Counting objects: 39, done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 39 (delta 3), reused 19 (delta 0), pack-reused 0
Unpacking objects: 100% (39/39), done.
==> Checking out branch master
==> ./buildForBrew.sh /usr/local/Cellar/applesimutils/HEAD-febb0d6
Last 15 lines from /Users/chirag/Library/Logs/Homebrew/applesimutils/01.buildForBrew.sh:
GenerateDSYMFile Build/Products/Release/applesimutils.dSYM Build/Products/Release/applesimutils
    cd /tmp/applesimutils-20170727-26741-rqyr0b/applesimutils
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil /tmp/applesimutils-20170727-26741-rqyr0b/applesimutils/Build/Products/Release/applesimutils -o /tmp/applesimutils-20170727-26741-rqyr0b/applesimutils/Build/Products/Release/applesimutils.dSYM

CodeSign Build/Products/Release/applesimutils
    cd /tmp/applesimutils-20170727-26741-rqyr0b/applesimutils
    export CODESIGN_ALLOCATE=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate

Signing Identity:     "-"

    /usr/bin/codesign --force --sign - --timestamp=none /tmp/applesimutils-20170727-26741-rqyr0b/applesimutils/Build/Products/Release/applesimutils

** BUILD SUCCEEDED **

cp: build/Build/Products/Release/applesimutils: No such file or directory

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/wix/homebrew-brew/issues
```