### PR TITLE
Fix location permission on Xcode 9

### DIFF
--- a/applesimutils/applesimutils/SetLocationPermission.m
+++ b/applesimutils/applesimutils/SetLocationPermission.m
@@ -11,11 +11,18 @@
 
 static void locationdCtl(NSString* simulatorId, BOOL stop)
 {
-	NSURL* devTools = [[SimUtils developerURL] URLByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/LaunchDaemons/com.apple.locationd.plist"];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    //New Simulator Runtime location for Xcode 9
+    NSString *plistPath = @"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/LaunchDaemons/com.apple.locationd.plist";
+    
+    if (![fileManager fileExistsAtPath:plistPath]){
+        NSURL* devTools = [[SimUtils developerURL] URLByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/LaunchDaemons/com.apple.locationd.plist"];
+        plistPath = devTools.path;
+    }
 	
 	NSTask* rebootTask = [NSTask new];
 	rebootTask.launchPath = @"/usr/bin/xcrun";
-	rebootTask.arguments = @[@"simctl", @"spawn", simulatorId, @"launchctl", stop ? @"unload" : @"load", devTools.path];
+	rebootTask.arguments = @[@"simctl", @"spawn", simulatorId, @"launchctl", stop ? @"unload" : @"load", plistPath];
 	[rebootTask launch];
 	[rebootTask waitUntilExit];
 }

--- a/applesimutils/applesimutils/SetLocationPermission.m
+++ b/applesimutils/applesimutils/SetLocationPermission.m
@@ -13,16 +13,15 @@ static void locationdCtl(NSString* simulatorId, BOOL stop)
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     //New Simulator Runtime location for Xcode 9
-    NSString *plistPath = @"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/LaunchDaemons/com.apple.locationd.plist";
+    NSURL *devTools = [[SimUtils developerURL] URLByAppendingPathComponent:@"Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/LaunchDaemons/com.apple.locationd.plist"];
     
-    if (![fileManager fileExistsAtPath:plistPath]){
-        NSURL* devTools = [[SimUtils developerURL] URLByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/LaunchDaemons/com.apple.locationd.plist"];
-        plistPath = devTools.path;
+    if (![fileManager fileExistsAtPath:devTools.path]){
+        devTools = [[SimUtils developerURL] URLByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/LaunchDaemons/com.apple.locationd.plist"];
     }
 	
 	NSTask* rebootTask = [NSTask new];
 	rebootTask.launchPath = @"/usr/bin/xcrun";
-	rebootTask.arguments = @[@"simctl", @"spawn", simulatorId, @"launchctl", stop ? @"unload" : @"load", plistPath];
+	rebootTask.arguments = @[@"simctl", @"spawn", simulatorId, @"launchctl", stop ? @"unload" : @"load", devTools.path];
 	[rebootTask launch];
 	[rebootTask waitUntilExit];
 }


### PR DESCRIPTION
Fixes the location issue mentioned in: https://github.com/wix/AppleSimulatorUtils/issues/10.

I've tested it with Xcode 9 and it works.
I'm not very experienced with Objective C so I hope I'm not uglifying your code or anything.
Also, I kept the old behavior for now (I'm guessing there are still some Xcode 8 users out there).