### PR TITLE
Fix bug from `brew install wix/brew/applesimutils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Install [brew](https://brew.sh), then:
 brew tap wix/brew
 brew install wix/brew/applesimutils
 ```
+(If xcode-select: error: tool 'xcodebuild' requires Xcode)
+try ```sudo xcode-select -s /Applications/Xcode.app/Contents/Developer```
 
 ## Usage
 


### PR DESCRIPTION
First time I run `brew install wix/brew/applesimutils`

I get this error

xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
cp: build/Build/Products/Release/applesimutils: No such file or directory

Fix by run 
`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`

Credit: https://github.com/nodejs/node-gyp/issues/569 
@jfmercer answered