### PR TITLE
Fixed problem with access permissions on iOS 12.

### DIFF
--- a/applesimutils/applesimutils/JPSimulatorHacksDB.h
+++ b/applesimutils/applesimutils/JPSimulatorHacksDB.h
@@ -30,7 +30,7 @@
 
 + (instancetype)databaseWithURL:(NSURL*)url;
 - (BOOL)close;
-- (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray *)arguments;
+- (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray<NSString*> *)arguments;
 - (NSString *)lastErrorMessage;
 - (BOOL)open;
 

--- a/applesimutils/applesimutils/JPSimulatorHacksDB.m
+++ b/applesimutils/applesimutils/JPSimulatorHacksDB.m
@@ -90,7 +90,7 @@
     return YES;
 }
 
-- (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray *)arrayArgs
+- (BOOL)executeUpdate:(NSString*)sql withArgumentsInArray:(NSArray<NSString*> *)arrayArgs
 {
     if (!_db) {
         return NO;
@@ -105,7 +105,7 @@
         return NO;
     }
 
-    id obj;
+    NSString* obj;
     int idx = 0;
     int queryCount = sqlite3_bind_parameter_count(pStmt);
     while (idx < queryCount) {
@@ -116,7 +116,7 @@
             break;
         }
         idx++;
-        sqlite3_bind_text(pStmt, idx, [[obj description] UTF8String], -1, SQLITE_STATIC);
+        sqlite3_bind_text(pStmt, idx, [obj UTF8String], -1, SQLITE_STATIC);
     }
 
     if (idx != queryCount) {

--- a/applesimutils/applesimutils/SetServicePermission.h
+++ b/applesimutils/applesimutils/SetServicePermission.h
@@ -8,9 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SetServicePermission : NSObject
 
 + (BOOL)isSimulatorReadyForPersmissions:(NSString*)simulatorId;
 + (BOOL)setPermisionStatus:(NSString*)status forService:(NSString*)service bundleIdentifier:(NSString*)bundleIdentifier simulatorIdentifier:(NSString*)simulatorId error:(NSError**)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/applesimutils/applesimutils/SimUtils.m
+++ b/applesimutils/applesimutils/SimUtils.m
@@ -79,17 +79,17 @@ const NSTimeInterval AppleSimUtilsRetryTimeout = 30.0f;
 
 + (NSURL*)URLForSimulatorId:(NSString*)simulatorId
 {
-	return [[[NSURL fileURLWithPath:NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES).firstObject] URLByAppendingPathComponent:@"/Developer/CoreSimulator/Devices/"] URLByAppendingPathComponent:simulatorId];
+	return [[[NSURL fileURLWithPath:NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES).firstObject] URLByAppendingPathComponent:@"Developer/CoreSimulator/Devices"] URLByAppendingPathComponent:simulatorId];
 }
 
 + (NSURL*)_dataURLForSimulatorId:(NSString*)simulatorId
 {
-	return [[self URLForSimulatorId:simulatorId] URLByAppendingPathComponent:@"data/"];
+	return [[self URLForSimulatorId:simulatorId] URLByAppendingPathComponent:@"data"];
 }
 
 + (NSURL *)libraryURLForSimulatorId:(NSString*)simulatorId
 {
-	return [[self _dataURLForSimulatorId:simulatorId] URLByAppendingPathComponent:@"Library/"];
+	return [[self _dataURLForSimulatorId:simulatorId] URLByAppendingPathComponent:@"Library"];
 }
 
 + (NSURL *)binaryURLForBundleId:(NSString*)bundleId simulatorId:(NSString*)simulatorId


### PR DESCRIPTION
Fixed problem with access on iOS 12.x #34   

Problem lies in request  
`query = @"INSERT INTO access (service, client, client_type, allowed, prompt_count) VALUES (?, ?, ?, ?, ?)";`   
It is strange but in iOS 12.0, this  request does not update record with same service and client, but add new record with same value.    
I've added delete request before.  
Also changed path to TCC.db, because original path had double '/'.    
Also  changed  `executeUpdate`'s parameter NSArray to NSArray<NSString*>, this is more clear (and correct?) than use [param description] to get string representation, because `description` method may return class name and other technical parameters in runtime. 
