### PR TITLE
Support new naming scheme for simctl simulator runtimes

### DIFF
--- a/applesimutils/applesimutils/main.m
+++ b/applesimutils/applesimutils/main.m
@@ -98,8 +98,12 @@ static NSArray* simulatorDevicesList()
 	
 	[runtimes enumerateObjectsUsingBlock:^(NSDictionary<NSString*, id>* _Nonnull runtime, NSUInteger idx, BOOL * _Nonnull stop) {
 		NSString* runtimeName = runtime[@"name"];
-		NSArray* runtimeDevices = [devices[runtimeName] filteredArrayUsingPredicate:availabilityPredicate];
-		[runtimeDevices setValue:runtime forKey:@"os"];
+        NSString* runtimeIdentifier = runtime[@"identifier"];
+        NSArray* nameDevices = devices[runtimeName] ?: @[];
+        NSArray* identifierDevices = devices[runtimeIdentifier] ?: @[];
+		NSArray* runtimeDevices = [nameDevices arrayByAddingObjectsFromArray:identifierDevices];
+        NSArray* filteredDevices = [runtimeDevices filteredArrayUsingPredicate:availabilityPredicate];
+		[filteredDevices setValue:runtime forKey:@"os"];
 		[allDevices addObjectsFromArray:runtimeDevices];
 	}];
 	

--- a/applesimutils/applesimutils/main.m
+++ b/applesimutils/applesimutils/main.m
@@ -98,11 +98,11 @@ static NSArray* simulatorDevicesList()
 	
 	[runtimes enumerateObjectsUsingBlock:^(NSDictionary<NSString*, id>* _Nonnull runtime, NSUInteger idx, BOOL * _Nonnull stop) {
 		NSString* runtimeName = runtime[@"name"];
-        NSString* runtimeIdentifier = runtime[@"identifier"];
-        NSArray* nameDevices = devices[runtimeName] ?: @[];
-        NSArray* identifierDevices = devices[runtimeIdentifier] ?: @[];
+		NSString* runtimeIdentifier = runtime[@"identifier"];
+		NSArray* nameDevices = devices[runtimeName] ?: @[];
+		NSArray* identifierDevices = devices[runtimeIdentifier] ?: @[];
 		NSArray* runtimeDevices = [nameDevices arrayByAddingObjectsFromArray:identifierDevices];
-        NSArray* filteredDevices = [runtimeDevices filteredArrayUsingPredicate:availabilityPredicate];
+		NSArray* filteredDevices = [runtimeDevices filteredArrayUsingPredicate:availabilityPredicate];
 		[filteredDevices setValue:runtime forKey:@"os"];
 		[allDevices addObjectsFromArray:runtimeDevices];
 	}];


### PR DESCRIPTION
See [this thread](https://github.com/Carthage/Carthage/issues/2691) from the Carthage project for more context behind these changes.

In Xcode 10.2, Apple changed the naming convention for iOS runtime versions. This is breaking `applesimutils`. An example output of `xcrun simctl list devices --json` on my machine looks like this:

```json
{
  "devices" : {
    "com.apple.CoreSimulator.SimRuntime.tvOS-12-1" : [

    ],
    "com.apple.CoreSimulator.SimRuntime.iOS-12-1" : [
      {
        "availability" : "(available)",
        "state" : "Booted",
        "isAvailable" : true,
        "name" : "iPhone 6",
        "udid" : "1D09F29D-983E-4F39-83FB-1A66DB505355",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone X",
        "udid" : "B4F0832A-95D9-4E78-912E-A8B8E7BB339C",
        "availabilityError" : ""
      }
    ],
    "com.apple.CoreSimulator.SimRuntime.iOS-12-0" : [

    ],
    "com.apple.CoreSimulator.SimRuntime.watchOS-5-1" : [

    ]
  }
}
```

The fix here is to look for devices based on both the old runtime name and the new runtime identifier.