### PR TITLE
Add option to skip SpringBoard restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
     --setPermissions        Sets the specified permissions and restarts SpringBoard for the changes to take effect
     --clearKeychain         Clears the simulator's keychain
     --restartSB             Restarts SpringBoard
+    --skipRestartSB         Skip Restarting SpringBoard
     --biometricEnrollment   Enables or disables biometric (Face ID/Touch ID) enrollment.
     --matchFace             Approves Face ID authentication request with a matching face
     --unmatchFace           Fails Face ID authentication request with a non-matching face

--- a/applesimutils/applesimutils/main.m
+++ b/applesimutils/applesimutils/main.m
@@ -398,6 +398,7 @@ int main(int argc, const char* argv[]) {
 							[LNUsageOption optionWithName:@"setPermissions" valueRequirement:GBValueRequired description:@"Sets the specified permissions and restarts SpringBoard for the changes to take effect"],
 							[LNUsageOption optionWithName:@"clearKeychain" valueRequirement:GBValueNone description:@"Clears the simulator's keychain"],
 							[LNUsageOption optionWithName:@"restartSB" valueRequirement:GBValueNone description:@"Restarts SpringBoard"],
+							[LNUsageOption optionWithName:@"skipRestartSB" valueRequirement:GBValueNone description:@"Skip Restarting SpringBoard"],
 							
 							[LNUsageOption optionWithName:@"biometricEnrollment" valueRequirement:GBValueRequired description:@"Enables or disables biometric (Face ID/Touch ID) enrollment."],
 							[LNUsageOption optionWithName:@"matchFace" valueRequirement:GBValueNone description:@"Approves Face ID authentication request with a matching face"],
@@ -607,6 +608,11 @@ int main(int argc, const char* argv[]) {
 			if([settings boolForKey:@"restartSB"])
 			{
 				needsSpringBoardRestart = YES;
+			}
+
+			if([settings boolForKey:@"skipRestartSB"])
+			{
+				needsSpringBoardRestart = NO;
 			}
 			
 			NSString* biometricEnrollment = [settings objectForKey:@"biometricEnrollment"];


### PR DESCRIPTION
Added option to skip SpringBoard restart.

Rationally:
Setting location and service permission does not require SpringBoard restart for permissions to take effect. Skipping SpringBoard restart saves at least 10 seconds of a test run.

I've tested locations and service permissions, both work without SpringBoard restart.
Unfortunately notifications permission do seem to require SpringBoard restart.