### PR TITLE
Fix NSTask race condition

### DIFF
--- a/applesimutils/applesimutils/NSTask+InputOutput.m
+++ b/applesimutils/applesimutils/NSTask+InputOutput.m
@@ -12,34 +12,51 @@
 
 - (int)launchAndWaitUntilExitReturningStandardOutputData:(out NSData* __autoreleasing __nullable * __nullable)stdOutData standardErrorData:(out NSData *__autoreleasing  _Nullable * __nullable)stdErrData
 {
+    dispatch_semaphore_t waitForOutput = dispatch_semaphore_create(0);
+    dispatch_semaphore_t waitForTaskTermination = dispatch_semaphore_create(0);
+    
 	NSPipe* outPipe = [NSPipe pipe];
 	NSMutableData* outData = [NSMutableData new];
 	self.standardOutput = outPipe;
 	outPipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle * _Nonnull fileHandle) {
-		[outData appendData:fileHandle.availableData];
+        NSData* newData = [fileHandle readDataOfLength:NSUIntegerMax];
+        
+        if (newData.length == 0) {
+            dispatch_semaphore_signal(waitForOutput);
+        } else {
+            [outData appendData:newData];
+        }
 	};
 	
 	NSPipe* errPipe = [NSPipe pipe];
 	NSMutableData* errData = [NSMutableData new];
 	self.standardError = errPipe;
 	errPipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle * _Nonnull fileHandle) {
-		[errData appendData:fileHandle.availableData];
+        NSData* newData = [fileHandle readDataOfLength:NSUIntegerMax];
+        
+        if (newData.length == 0) {
+            dispatch_semaphore_signal(waitForOutput);
+        } else {
+            [errData appendData:newData];
+        }
 	};
 	
-	dispatch_semaphore_t waitForTermination = dispatch_semaphore_create(0);
-	
 	self.terminationHandler = ^(NSTask* _Nonnull task) {
-		outPipe.fileHandleForReading.readabilityHandler = nil;
-		errPipe.fileHandleForReading.readabilityHandler = nil;
-		
-		dispatch_semaphore_signal(waitForTermination);
+		dispatch_semaphore_signal(waitForTaskTermination);
 	};
 	
 	LNLog(LNLogLevelDebug, @"Running “%@”%@", self.launchPath, self.arguments.count > 0 ? [NSString stringWithFormat:@" with argument%@: “%@”", self.arguments.count > 1 ? @"s" : @"", [self.arguments componentsJoinedByString:@" "]] : @"");
 	
 	[self launch];
 	
-	dispatch_semaphore_wait(waitForTermination, DISPATCH_TIME_FOREVER);
+    // Wait twice, once for stdout and once for stderr
+	dispatch_semaphore_wait(waitForOutput, DISPATCH_TIME_FOREVER);
+    dispatch_semaphore_wait(waitForOutput, DISPATCH_TIME_FOREVER);
+    // also wait for the NSTask to terminate, otherwise we can't read terminationStatus
+    dispatch_semaphore_wait(waitForTaskTermination, DISPATCH_TIME_FOREVER);
+    
+    outPipe.fileHandleForReading.readabilityHandler = nil;
+    errPipe.fileHandleForReading.readabilityHandler = nil;
 	
 	NSString* stdOutStr = [[[NSString alloc] initWithData:outData encoding:NSUTF8StringEncoding] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
 	if(stdOutStr.length > 0)


### PR DESCRIPTION
Fixes #88, fixes #89 

According to https://stackoverflow.com/questions/49184623/nstask-race-condition-with-readabilityhandler-block, there seems to be a possible race condition that causes the NSTask termination handler to fire before the data is finished being read. Additionally, there seems to be some issues with reading from `fileHandle.availableData` directly.

This PR implements the two fixes suggested by the stackoverflow post, and subsequently fixes #88 and #89 from my personal testing (I was able to reliably repro the first issue at least) 