### PR TITLE
Support Xcode 15's separate runtime bundles

### DIFF
--- a/applesimutils/applesimutils.xcodeproj/project.pbxproj
+++ b/applesimutils/applesimutils.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 				391EBF361E91212B0009AACD /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		391596DD1E8CBAA900FDD6F5 /* Products */ = {
 			isa = PBXGroup;

--- a/applesimutils/applesimutils/ClearKeychain.h
+++ b/applesimutils/applesimutils/ClearKeychain.h
@@ -8,6 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSURL* securitydURL(void);
+extern NSURL* securitydURL(NSURL* runtimeBundleURL);
 
-extern void performClearKeychainPass(NSString* simulatorIdentifier);
+extern void performClearKeychainPass(NSString* simulatorIdentifier, NSURL* runtimeBundleURL);

--- a/applesimutils/applesimutils/ClearMedia.h
+++ b/applesimutils/applesimutils/ClearMedia.h
@@ -8,4 +8,4 @@
 
 #import <Foundation/Foundation.h>
 
-extern void performClearMediaPass(NSString* simulatorIdentifier);
+extern void performClearMediaPass(NSString* simulatorIdentifier, NSURL* runtimeBundleURL);

--- a/applesimutils/applesimutils/ClearMedia.m
+++ b/applesimutils/applesimutils/ClearMedia.m
@@ -9,19 +9,19 @@
 #import "ClearMedia.h"
 #import "SimUtils.h"
 
-extern NSURL* assetsdURL(void)
+extern NSURL* assetsdURL(NSURL* runtimeBundleURL)
 {
 	static NSURL *assetsdURL;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
-		assetsdURL = [SimUtils launchDaemonPlistURLForDaemon:@"com.apple.assetsd"];
+		assetsdURL = [SimUtils launchDaemonPlistURLForDaemon:@"com.apple.assetsd" runtimeBundleURL:runtimeBundleURL];
 	});
 	return assetsdURL;
 }
 
-static void assetsdCtl(NSString* simulatorId, BOOL stop)
+static void assetsdCtl(NSString* simulatorId, NSURL* runtimeBundleURL, BOOL stop)
 {
-	NSURL *locationdDaemonURL = assetsdURL();
+	NSURL *locationdDaemonURL = assetsdURL(runtimeBundleURL);
 	NSCAssert(locationdDaemonURL != nil, @"Launch daemon “com.apple.mobileassetd” not found. Please open an issue.");
 	
 	NSTask* rebootTask = [NSTask new];
@@ -31,11 +31,11 @@ static void assetsdCtl(NSString* simulatorId, BOOL stop)
 	[rebootTask waitUntilExit];
 }
 
-void performClearMediaPass(NSString* simulatorIdentifier)
+void performClearMediaPass(NSString* simulatorIdentifier, NSURL* runtimeBundleURL)
 {
-	assetsdCtl(simulatorIdentifier, YES);
+	assetsdCtl(simulatorIdentifier, runtimeBundleURL, YES);
 	NSURL* mediaURL = [[SimUtils dataURLForSimulatorId:simulatorIdentifier] URLByAppendingPathComponent:@"Media"];
 	[NSFileManager.defaultManager removeItemAtURL:[mediaURL URLByAppendingPathComponent:@"DCIM"] error:NULL];
 	[NSFileManager.defaultManager removeItemAtURL:[mediaURL URLByAppendingPathComponent:@"PhotoData"] error:NULL];
-	assetsdCtl(simulatorIdentifier, NO);
+	assetsdCtl(simulatorIdentifier, runtimeBundleURL, NO);
 }

--- a/applesimutils/applesimutils/SetLocationPermission.h
+++ b/applesimutils/applesimutils/SetLocationPermission.h
@@ -10,8 +10,8 @@
 
 @interface SetLocationPermission : NSObject
 
-+ (NSURL*)locationdURL;
++ (NSURL*)locationdURLForRuntimeBundleURL:(NSURL*)runtimeBundleURL;
 
-+ (BOOL)setLocationPermission:(NSString*)permission forBundleIdentifier:(NSString*)bundleIdentifier simulatorIdentifier:(NSString*)simulatorId error:(NSError**)error;
++ (BOOL)setLocationPermission:(NSString*)permission forBundleIdentifier:(NSString*)bundleIdentifier simulatorIdentifier:(NSString*)simulatorId runtimeBundleURL:(NSURL*)runtimeBundleURL error:(NSError**)error;
 
 @end

--- a/applesimutils/applesimutils/SetLocationPermission.m
+++ b/applesimutils/applesimutils/SetLocationPermission.m
@@ -9,9 +9,9 @@
 #import "SetLocationPermission.h"
 #import "SimUtils.h"
 
-static void startStopLocationdCtl(NSString* simulatorId, BOOL stop)
+static void startStopLocationdCtl(NSString* simulatorId, NSURL* runtimeBundleURL, BOOL stop)
 {
-	NSURL *locationdDaemonURL = [SetLocationPermission locationdURL];
+	NSURL *locationdDaemonURL = [SetLocationPermission locationdURLForRuntimeBundleURL:runtimeBundleURL];
 	NSCAssert(locationdDaemonURL != nil, @"Launch daemon “com.apple.locationd” not found. Please open an issue.");
 	
 	NSTask* rebootTask = [NSTask new];
@@ -23,17 +23,17 @@ static void startStopLocationdCtl(NSString* simulatorId, BOOL stop)
 
 @implementation SetLocationPermission
 
-+ (NSURL*)locationdURL
++ (NSURL*)locationdURLForRuntimeBundleURL:(NSURL*)runtimeBundleURL
 {
 	static NSURL *locationdDaemonURL;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
-		 locationdDaemonURL = [SimUtils launchDaemonPlistURLForDaemon:@"com.apple.locationd"];
+		 locationdDaemonURL = [SimUtils launchDaemonPlistURLForDaemon:@"com.apple.locationd" runtimeBundleURL:runtimeBundleURL];
 	});
 	return locationdDaemonURL;
 }
 
-+ (BOOL)setLocationPermission:(NSString*)permission forBundleIdentifier:(NSString*)bundleIdentifier simulatorIdentifier:(NSString*)simulatorId error:(NSError**)error
++ (BOOL)setLocationPermission:(NSString*)permission forBundleIdentifier:(NSString*)bundleIdentifier simulatorIdentifier:(NSString*)simulatorId runtimeBundleURL:(NSURL*)runtimeBundleURL error:(NSError**)error
 {
 	LNLog(LNLogLevelDebug, @"Setting location permission");
 	
@@ -86,11 +86,11 @@ static void startStopLocationdCtl(NSString* simulatorId, BOOL stop)
 		locationClients[bundleIdentifier] = bundlePermissions;
 	}
 	
-	startStopLocationdCtl(simulatorId, YES);
+	startStopLocationdCtl(simulatorId, runtimeBundleURL, YES);
 	
 	[[NSPropertyListSerialization dataWithPropertyList:locationClients format:NSPropertyListBinaryFormat_v1_0 options:0 error:NULL] writeToURL:plistURL atomically:YES];
 	
-	startStopLocationdCtl(simulatorId, NO);
+	startStopLocationdCtl(simulatorId, runtimeBundleURL, NO);
 	
 	return YES;
 }

--- a/applesimutils/applesimutils/SimUtils.h
+++ b/applesimutils/applesimutils/SimUtils.h
@@ -18,7 +18,7 @@ extern const NSTimeInterval AppleSimUtilsRetryTimeout;
 + (NSURL*)dataURLForSimulatorId:(NSString*)simulatorId;
 + (NSURL*)libraryURLForSimulatorId:(NSString*)simulatorId;
 + (NSURL*)binaryURLForBundleId:(NSString*)bundleId simulatorId:(NSString*)simulatorId;
-+ (NSURL*)launchDaemonPlistURLForDaemon:(NSString*)daemon;
++ (NSURL*)launchDaemonPlistURLForDaemon:(NSString*)daemon runtimeBundleURL:(NSURL*)runtimeBundleURL;
 + (void)restartSpringBoardForSimulatorId:(NSString*)simulatorId;
 
 + (void)registerCleanupBlock:(dispatch_block_t)block;


### PR DESCRIPTION
Xcode 15 ships the iOS runtime outside of Xcode, so hardcoding the path in `+[SimUtils launchDaemonPlistURLForDaemon:]` no longer works. This passes the runtime URL down to that method so it can dynamically use the correct runtime.

Tested against Xcode 15 and Xcode 14.