### PR TITLE
Add Field Filtering for Simulator List Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A collection of utils for Apple simulators.
 Usage Examples:
     applesimutils --byId <simulator UDID> --bundle <bundle identifier> --setPermissions "<permission1>, <permission2>, ..."
     applesimutils --byName <simulator name> --byOS <simulator OS> --bundle <bundle identifier> --setPermissions "<permission1>, <permission2>, ..."
-    applesimutils --list [--byName <simulator name>] [--byOS <simulator OS>] [--byType <simulator device type>] [--maxResults <int>]
+    applesimutils --list [--byName <simulator name>] [--byOS <simulator OS>] [--byType <simulator device type>] [--maxResults <int>] [--fields <key1,key2,...>]
     applesimutils --booted --biometricEnrollment <YES/NO>
     applesimutils --booted --biometricMatch
 
@@ -41,6 +41,7 @@ Options:
     --list, -l                    Lists available simulators
     --bundle, -b                  The app bundle identifier
     --maxResults                  Limits the number of results returned from --list
+    --fields                      Comma-separated list of fields to include in --list output (e.g. "udid,os,identifier")
 
     --setPermissions, -sp         Sets the specified permissions and restarts SpringBoard for the changes to take effect
     --clearKeychain, -ck          Clears the simulator's keychain


### PR DESCRIPTION
Resolves #122

This PR introduces a new `--fields` option that allows users to specify which fields they want to include in the `--list` command output. This feature helps reduce noise and makes the output more focused on the data that matters to the user.

## What's New
- Added new `--fields` option that accepts a comma-separated list of field names
- Output is filtered to only include the specified fields while preserving the nested structure
- Fields can be deeply nested (e.g., "udid,os.version,deviceType.name")

## Example Usage
```bash
# Only show UDID and OS version
applesimutils --list --fields "udid,os,version"

# Get device state
applesimutils --list --fields "udid,state"
```

This enhancement makes the tool more flexible when used in scripts and automation pipelines where specific simulator information is needed.

Required for https://github.com/wix/Detox/pull/4335